### PR TITLE
Round up the result.ruleImpact value to neaten results up

### DIFF
--- a/tasks/lib/output.coffee
+++ b/tasks/lib/output.coffee
@@ -29,7 +29,8 @@ exports.init = (grunt) ->
     for title, result of rulesets
       title  = firstToUpperCaseAndAddSpace(title)
       title += bufferSpace(title)
-      print "#{title}| #{result.ruleImpact}"
+      ruleImpact  = Math.ceil(result.ruleImpact * 100)/100;
+      print "#{title}| #{ruleImpact}"
 
   #
   # Generate statistics output


### PR DESCRIPTION
The API value ruleScore has been deprecated and replaced with ruleImpact, that change was implemented in 0.0.8, but looking at the docs ruleImpact works somewhat differently.

> "The impact (unbounded floating point value) that implementing the suggestions for this rule would have on making the page > faster. Impact is comparable between rules to determine which rule's suggestions would have a higher or lower impact on making a page faster. For instance, if enabling compression would save 1MB, while optimizing images would save 500kB, the enable compression rule would have 2x the impact of the image optimization rule, all other things being equal." - _https://developers.google.com/speed/docs/insights/v1/reference_

This has lead to the values outputted being much longer. This pull request rounds up the values to make them more readable.

**Before**
![pagespeed](https://f.cloud.github.com/assets/894092/1622331/6dd59908-56a3-11e3-9990-6f7bc8818c90.png)

**After**
![pagespeedchange](https://f.cloud.github.com/assets/894092/1622303/e66d9f9c-56a2-11e3-86a7-90b672b81806.png)
