### PR TITLE
Output to .json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ results
 node_modules
 
 npm-debug.log
+
+pagespeed.json

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -26,6 +26,13 @@ module.exports = (grunt) ->
           locale: "en_GB"
           strategy: "mobile"
           threshold: 62
+      toFile:
+      	options:
+      		paths: ["/speed/docs/insights/about", "/speed/docs/insights/v1/getting_started"]
+      		locale: "en_GB"
+      		strategy: "desktop"
+      		file: "pagespeed"
+      		filepath: "./"
 
   grunt.loadTasks 'tasks'
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ _This task is a [multi task][] so any targets, files and options should be speci
 [multi task]: https://github.com/gruntjs/grunt/wiki/Configuring-tasks
 
 
-###Usage Example
+### Usage Example
 
 
     pagespeed: {
@@ -76,9 +76,12 @@ _This task is a [multi task][] so any targets, files and options should be speci
       saveOutputToFile: {
         options: {
             paths: ["/speed/docs/insights/v1/getting_started", "/speed/docs/about"],
+            locale: "en_GB",
+            strategy: "desktop",
+            threshold: 80,
             format: "json",
-            file: "pagespeed.json",
-            filepath: "tests/"
+            file: "pagespeed",
+            filepath: "results/"
         }
       }
     }

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ _This task is a [multi task][] so any targets, files and options should be speci
 
 ### Usage Example
 
-
+```js
     pagespeed: {
       options: {
         nokey: true,
@@ -85,6 +85,7 @@ _This task is a [multi task][] so any targets, files and options should be speci
         }
       }
     }
+```
 
 ### Options
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ _This task is a [multi task][] so any targets, files and options should be speci
           threshold: 80
         }
       }
+      saveOutputToFile: {
+        options: {
+            paths: ["/speed/docs/insights/v1/getting_started", "/speed/docs/about"],
+            format: "json",
+            file: "pagespeed.json",
+            filepath: "tests/"
+        }
+      }
     }
 
 ### Options
@@ -84,6 +92,17 @@ Use the nokey option to test-drive PageSpeed Insights before acquiring a key for
 
 #### key
 Type: `String`
+
+#### format
+Type: `String`, values(json|cli|tap)
+
+#### file
+Type: `String`, filename for output
+
+If file is set, format is set to json.
+
+#### filepath
+Type: `String` path for output
 
 [Google API Key](https://code.google.com/apis/console/)
 

--- a/tasks/lib/config.coffee
+++ b/tasks/lib/config.coffee
@@ -13,9 +13,14 @@ exports.init = (grunt) ->
   exports   = {}
   config    = {}
   DEFAULT_THRESHOLD = 70
+  DEFAULT_FORMAT = 'cli'
 
   key = ->
     config["key"] if config["key"]
+
+  format = ->
+    return config["format"] if config["format"]
+    return DEFAULT_FORMAT unless config["format"]
 
   nokey = ->
     config["nokey"] if config["nokey"]
@@ -38,6 +43,20 @@ exports.init = (grunt) ->
   strategy = ->
     config["strategy"] if config["strategy"]
 
+  timeout = ->
+    config["timeout"] if config["timeout"]
+
+  file = ->
+    config["file"] + ".json" if config["file"]
+
+  filepath = ->
+    config["filepath"] if config["filepath"]
+
+  format = ->
+    return "json" if config["file"]
+    return config["format"] if config["format"] && config['format'].match(/json|cli|tap/)
+    'cli' unless config["format"] && config['format'].match(/json|cli|tap/)
+
   threshold = ->
     return DEFAULT_THRESHOLD unless config["threshold"]
     config["threshold"]
@@ -56,6 +75,9 @@ exports.init = (grunt) ->
       param["locale"] = locale()
       param["strategy"] = strategy()
       param["threshold"] = threshold()
+      param["filepath"] = filepath()
+      param["file"] = file()
+      param["format"] = format() if config["format"]
       param
 
     params

--- a/tasks/pagespeed.coffee
+++ b/tasks/pagespeed.coffee
@@ -24,18 +24,21 @@ module.exports = (grunt) ->
     for index, options of params
       # safe output to file
       if options.file
-        psi(options.url, options, (err, data) ->
+        psi(options.url, options).then (data) ->
           current++
-          unless err
-            grunt.log.write '.'
-            output.push {'url': options.url, 'score': data.score, 'pageStats': data.pageStats }
+          grunt.log.write 'url:' + data.id + ' '
+          grunt.log.ok 'score:' + data.ruleGroups.SPEED.score
+          # full output
+          # output.push {data}
+          output.push {'url': data.id, 'score': data.ruleGroups.SPEED.score, 'pageStats': data.pageStats }
           if numOfTests == current
-            #console.log filepath + filename
             grunt.file.write options.filepath + options.file, JSON.stringify(output, false, 4)
             grunt.log.writeln(' ')
             grunt.log.ok 'Wrote output to ' + options.filepath + options.file
-            done(err)
-        )
+            done()
+        .catch (err) ->
+          current++
+          done(err) if numOfTests == current
       # print output to cli
       else
         psi.output(options.url, options).then (response) ->

--- a/tasks/pagespeed.coffee
+++ b/tasks/pagespeed.coffee
@@ -38,7 +38,9 @@ module.exports = (grunt) ->
         )
       # print output to cli
       else
-        psi.output(options.url, options, (err, response) ->
+        psi.output(options.url, options).then (response) ->
+          current++
+          done() if numOfTests == current
+        .catch (err) ->
           current++
           done(err) if numOfTests == current
-        )

--- a/tasks/pagespeed.coffee
+++ b/tasks/pagespeed.coffee
@@ -19,10 +19,26 @@ module.exports = (grunt) ->
     numOfTests = params.length
     current    = 0
 
+    output = []
+
     for index, options of params
-      psi.output(options.url, options).then (response) ->
-        current++
-        done() if numOfTests == current
-      .catch (err) ->
-        current++
-        done(err) if numOfTests == current
+      # safe output to file
+      if options.file
+        psi(options.url, options, (err, data) ->
+          current++
+          unless err
+            grunt.log.write '.'
+            output.push {'url': options.url, 'score': data.score, 'pageStats': data.pageStats }
+          if numOfTests == current
+            #console.log filepath + filename
+            grunt.file.write options.filepath + options.file, JSON.stringify(output, false, 4)
+            grunt.log.writeln(' ')
+            grunt.log.ok 'Wrote output to ' + options.filepath + options.file
+            done(err)
+        )
+      # print output to cli
+      else
+        psi.output(options.url, options, (err, response) ->
+          current++
+          done(err) if numOfTests == current
+        )

--- a/tasks/pagespeed.coffee
+++ b/tasks/pagespeed.coffee
@@ -20,8 +20,9 @@ module.exports = (grunt) ->
     current    = 0
 
     for index, options of params
-      current++
       psi.output(options.url, options).then (response) ->
+        current++
         done() if numOfTests == current
       .catch (err) ->
+        current++
         done(err) if numOfTests == current

--- a/tasks/pagespeed.coffee
+++ b/tasks/pagespeed.coffee
@@ -20,8 +20,8 @@ module.exports = (grunt) ->
     current    = 0
 
     for index, options of params
+      current++
       psi.output(options.url, options).then (response) ->
-        current++
         done() if numOfTests == current
       .catch (err) ->
         done(err) if numOfTests == current


### PR DESCRIPTION
I've pulled and merged @mkilpatrick's and @embats's changes, so my pull request contains fix for issue #26 and has an option to save output into .json file.

Solution has been tested on this repository https://github.com/IDTdesign/bossrev-psi

You can test it on your own project by adding direct git link to my fork:

```json
  "devDependencies": {
    "grunt": "^1.0.1",
    "grunt-pagespeed": "git://github.com/paulradzkov/grunt-pagespeed.git"
  }
```

